### PR TITLE
 Check major mode in buffers not visiting a file

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -1264,13 +1264,14 @@ by quickrun.el. But you can register your own command for some languages")
     (expand-file-name (concat dir (make-temp-name "qr_") suffix))))
 
 (defun quickrun--command-key (src)
-  (let ((file-type (and src (quickrun--decide-file-type src)))
+  (let ((file-type (or (and src (quickrun--decide-file-type src))
+                       (quickrun--find-from-major-mode-alist)))
         (use-prefix-p (and (consp current-prefix-arg)
                            (= (car current-prefix-arg) 4))))
     (or (and use-prefix-p (quickrun--prompt))
         (and quickrun-option-cmd-alist "_user_defined") ;; setting dummy value
         quickrun-option-cmdkey
-        (and (not src) (quickrun--prompt))
+        (and (not file-type) (quickrun--prompt))
         (gethash file-type quickrun--command-key-table)
         file-type
         (quickrun--prompt))))


### PR DESCRIPTION
* quickrun.el (quickrun--command-key): Check major mode in buffers not visiting a file

;; Suppose you create a new buffer (not visiting a file) in sh-mode:
C-x b foo RET
M-x sh-mode RET
;; Now you write or paste some code:
echo "foobar"
;; It's nice if the language is automatically detected (i.e. without being prompted):
M-x quickrun RET
