### PR TITLE
Use (buffer-file-name) to select "go" subcommand

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -347,7 +347,8 @@ FMT and ARGS passed `message'."
 
     ("go/go"  .  ((:command . "go")
                   (:exec    . ((lambda ()
-                                 (if (string-match-p "_test\\.go\\'" (buffer-name))
+                                 (if (string-match-p "_test\\.go\\'" (or (buffer-file-name)
+                                                                         (buffer-name)))
                                      "%c test %o"
                                    "%c run %o %s %a"))))
                   (:compile-only . "%c build -o /dev/null %s %o %a")


### PR DESCRIPTION
Fixes invalid "go run" invocation when using non-default
`uniquify-buffer-name-style'.

I use `(uniquify-buffer-name-style (quote reverse) nil (uniquify))` and so the existing predicate for tests doesn't match:

`go run: cannot run *_test.go files (dummy_test.go)`
