### PR TITLE
Fix small docstring issues

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -81,23 +81,24 @@
 (defvar quickrun--original-outputter nil)
 
 (defmacro quickrun--awhen (test &rest body)
-  "Not documented."
+  "Anaphoric when.  If TEST is non-nil, do BODY (include `it')."
   (declare (indent 1))
   `(let ((it ,test)) (when it ,@body)))
 
 (defun quickrun--mklist (obj)
-  "Not documented."
+  "Ensure OBJ is a list."
   (if (listp obj)
       obj
     (list obj)))
 
 (defsubst quickrun--log (fmt &rest args)
-  "Not documented."
+  "Log if `quickrun-debug' is non-nil.
+FMT and ARGS passed `message'."
   (when quickrun-debug
     (apply 'message fmt args)))
 
 (defsubst quickrun--windows-p ()
-  "Not documented."
+  "Return non-nil if windows."
   (memq system-type '(ms-dos windows-nt cygwin)))
 
 ;;
@@ -158,7 +159,7 @@
 
 ;; hooks
 (defvar quickrun-after-run-hook nil
-  "Run hook after execute quickrun")
+  "Run hook after execute quickrun.")
 
 (defvar quickrun--temporary-file nil)
 
@@ -463,14 +464,14 @@
                  (:description . "Compile Kotlin file and execute"))))
 
   "List of each programming languages information.
-Parameter form is (\"language\" . parameter-alist). parameter-alist has
+Parameter form is (\"language\" . parameter-alist).  parameter-alist has
 5 keys and those values , :command, :exec, :remove.
-:command pair is mandatory, other pairs are optional. Associated value
+:command pair is mandatory, other pairs are optional.  Associated value
 should be string or a function which returns a string object.
 
 Assosiated values are
 :command = Program name which is used compiled or executed source code.
-:exec    = Exec command template. If you omit this parameter, quickrun
+:exec    = Exec command template.  If you omit this parameter, quickrun
            use default parameter \"%c %o %s %a\".
 :remove  = Remove files or directories templates.
            Compiler or executor generates temporary files,
@@ -479,8 +480,7 @@ Assosiated values are
 Every pair should be dot-pair.
 
 See explanation of quickrun--template-place-holders
-if you set your own language configuration.
-")
+if you set your own language configuration.")
 
 (defvar quickrun-file-alist
   '(("\\.c\\'" . "c")
@@ -531,7 +531,7 @@ if you set your own language configuration.
     ("\\.jl\\'" . "julia")
     ("\\.\\(gpi\\|plt\\)\\'" . "gnuplot")
     ("\\.kt\\'" . "kotlin"))
-  "Alist of (file-regexp . key)")
+  "Alist of (file-regexp . key).")
 
 (defvar quickrun--major-mode-alist
   '((c-mode . "c")
@@ -583,7 +583,7 @@ if you set your own language configuration.
     (julia-mode . "julia")
     (gnuplot-mode . "gnuplot")
     (kotlin-mode . "kotlin"))
-  "Alist of major-mode and langkey")
+  "Alist of `major-mode' and langkey.")
 
 (defun quickrun--decide-file-type (filename)
   "Decide file type by FILENAME."
@@ -813,7 +813,7 @@ if you set your own language configuration.
     (quickrun--pop-to-buffer buf (lambda () (read-only-mode +1)))))
 
 (defun quickrun--remove-temp-files ()
-  "Removes temporary files."
+  "Remove temporary files."
   (quickrun--log "Quickrun remove %s" quickrun--remove-files)
   (dolist (file quickrun--remove-files)
     (cond
@@ -822,7 +822,7 @@ if you set your own language configuration.
   (setq quickrun--remove-files nil))
 
 (defun quickrun--kill-running-process ()
-  "Kills running process.."
+  "Kill running process."
   (interactive)
   (let ((proc (get-buffer-process (current-buffer))))
     (if (not proc)
@@ -1022,8 +1022,7 @@ Place holders are beginning with '%' and replaced by:
 %n: absolute path of source code without extension
 %N: source code path without extension
 %e: absolute path of source code with executable extension(.exe, .out, .class)
-%E: source code name with executable extension
-")
+%E: source code name with executable extension")
 
 (defun quickrun--executable-suffix (command)
   "Not documented."
@@ -1143,8 +1142,8 @@ Place holders are beginning with '%' and replaced by:
     "d" "markdown" "coffee" "scala" "groovy" "sass" "less" "shellscript" "awk"
     "lua" "rust" "dart" "elixir" "tcl" "jsx" "typescript" "fortran" "haml"
     "swift" "ats" "r" "nim" "nimscript" "fish" "julia" "gnuplot" "kotlin")
-  "Programming languages and Markup languages supported as default
-by quickrun.el. But you can register your own command for some languages")
+  "Programming languages and Markup languages supported as default.
+But you can register your own command for some languages")
 
 (defvar quickrun--command-key-table
   (make-hash-table :test 'equal))
@@ -1153,7 +1152,7 @@ by quickrun.el. But you can register your own command for some languages")
 (defun quickrun-set-default (lang key)
   "Set `key' as default key in programing language `lang'."
   (unless (assoc key quickrun--language-alist)
-    (error "%s is not registered." key))
+    (error "%s is not registered" key))
   (puthash lang key quickrun--command-key-table))
 
 (defun quickrun--override-command (cmdkey cmd-alist)
@@ -1176,7 +1175,7 @@ by quickrun.el. But you can register your own command for some languages")
   (if override
       (quickrun--override-command key (copy-alist alist))
     (if (not (assoc :command alist))
-        (error "not found :command parameter in language alist")
+        (error "Not found :command parameter in language alist")
       (push (cons key (copy-alist alist)) quickrun--language-alist)))
   (let ((cmd-key (or default key)))
     (when default
@@ -1221,11 +1220,10 @@ by quickrun.el. But you can register your own command for some languages")
     ("markdown" . ("Markdown.pl" "kramdown" "bluecloth" "redcarpet" "pandoc"))
     ("clojure" . ("jark" "clj-env-dir"))
     ("go" . ("go" "gccgo")))
-  "Candidates of language which has some compilers or interpreters")
+  "Candidates of language which has some compilers or interpreters.")
 
 (defun quickrun--init-command-key-table ()
-  "Not documented."
-  "Decide command for programing language which has multiple candidates"
+  "Decide command for programing language which has multiple candidates."
   (dolist (lang quickrun--support-languages)
     (puthash lang lang quickrun--command-key-table))
   (cl-loop for (lang . candidates) in quicklang/lang-candidates
@@ -1258,7 +1256,7 @@ by quickrun.el. But you can register your own command for some languages")
 (defun quickrun (&rest plist)
   "Run commands quickly for current buffer
    With universal prefix argument(C-u), select command-key,
-   With double prefix argument(C-u C-u), run in compile-only-mode"
+   With double prefix argument(C-u C-u), run in compile-only-mode."
   (interactive)
   (quickrun--set-executed-file)
   (let ((beg (or (plist-get plist :start) (point-min)))
@@ -1281,7 +1279,7 @@ by quickrun.el. But you can register your own command for some languages")
 
 ;;;###autoload
 (defun quickrun-with-arg (arg)
-  "Run commands quickly for current buffer with arguments"
+  "Run commands quickly for current buffer with arguments."
   (interactive
    (list (read-string "QuickRun Arg: " nil 'quickrun--with-arg--history)))
   (let ((quickrun-option-args arg))
@@ -1304,13 +1302,13 @@ by quickrun.el. But you can register your own command for some languages")
 
 ;;;###autoload
 (defun quickrun-region (start end)
-  "Run commands with specified region"
+  "Run commands with specified region."
   (interactive "r")
   (quickrun--region-command-common start end))
 
 ;;;###autoload
 (defun quickrun-replace-region (start end)
-  "Run commands with specified region and replace"
+  "Run commands with specified region and replace."
   (interactive "r")
   (setq quickrun--original-outputter quickrun-option-outputter)
   (let ((quickrun-option-outputter 'replace))
@@ -1318,7 +1316,7 @@ by quickrun.el. But you can register your own command for some languages")
 
 ;;;###autoload
 (defun quickrun-eval-print (start end)
-  "Run commands with specified region and replace"
+  "Run commands with specified region and replace."
   (interactive "r")
   (setq quickrun--original-outputter quickrun-option-outputter)
   (let ((quickrun-option-outputter 'eval-print))
@@ -1326,14 +1324,14 @@ by quickrun.el. But you can register your own command for some languages")
 
 ;;;###autoload
 (defun quickrun-compile-only ()
-  "Exec only compilation"
+  "Exec only compilation."
   (interactive)
   (let ((quickrun--compile-only-flag t))
     (quickrun)))
 
 ;;;###autoload
 (defun quickrun-shell ()
-  "Run commands in shell for interactive programs"
+  "Run commands in shell for interactive programs."
   (interactive)
   (let ((quickrun--run-in-shell t)
         (quickrun-timeout-seconds nil))
@@ -1449,7 +1447,7 @@ by quickrun.el. But you can register your own command for some languages")
 
 ;;;###autoload
 (define-minor-mode quickrun-autorun-mode
-  "`quickrun' after saving buffer"
+  "`quickrun' after saving buffer."
   :init-value nil
   :global nil
   :lighter " QAR"
@@ -1467,7 +1465,8 @@ by quickrun.el. But you can register your own command for some languages")
     ("Run with shell" . quickrun--helm-action-shell)
     ("Run with argument" . quickrun--helm-run-with-arg)
     ("Replace region" . quickrun--helm-action-replace-region)
-    ("Eval and insert as comment" . quickrun--helm-action-eval-print)))
+    ("Eval and insert as comment" . quickrun--helm-action-eval-print))
+  "Not documented.")
 
 (defvar helm-quickrun-source
   `((name . "Choose Command-Key")
@@ -1476,7 +1475,7 @@ by quickrun.el. But you can register your own command for some languages")
                     (cl-loop for (cmd-key . cmd-info) in quickrun--language-alist
                              collect (quickrun--helm-candidate cmd-key cmd-info))))
     (action . ,helm-quickrun--actions))
-  "helm/anything source of `quickrun'")
+  "The helm/anything source of `quickrun'.")
 
 (defvar quickrun--helm-history nil)
 
@@ -1485,7 +1484,7 @@ by quickrun.el. But you can register your own command for some languages")
     (volatile)
     (candidates . quickrun--helm-history)
     (action . ,helm-quickrun--actions))
-  "helm source of `quickrun' history")
+  "The helm source of `quickrun' history.")
 
 (defun quickrun--helm-candidate (cmd-key cmd-info)
   "Not documented."
@@ -1543,7 +1542,7 @@ by quickrun.el. But you can register your own command for some languages")
   "Run quickrun with `anything'."
   (interactive)
   (unless (featurep 'anything)
-    (error "anything is not installed."))
+    (error "Anything is not installed"))
   (anything helm-quickrun-source))
 
 ;;;###autoload
@@ -1551,7 +1550,7 @@ by quickrun.el. But you can register your own command for some languages")
   "Run quickrun with `helm'."
   (interactive)
   (unless (featurep 'helm)
-    (error "helm is not installed."))
+    (error "Helm is not installed"))
   (let ((sources (if quickrun--helm-history
                      '(helm-quickrun-history-source helm-quickrun-source)
                    '(helm-quickrun-source))))


### PR DESCRIPTION
Hi!
Thanks for maintain this project!

I fix small docstring issues.

```emacs-lisp
 quickrun…    84     warning         Argument ‘test’ should appear (as TEST) in the doc string (emacs-lisp-checkdoc)
 quickrun…    89     warning         Argument ‘obj’ should appear (as OBJ) in the doc string (emacs-lisp-checkdoc)
 quickru…    95     warning         Argument ‘fmt’ should appear (as FMT) in the doc string (emacs-lisp-checkdoc)
 quickru…   108     warning         Argument ‘name’ should appear (as NAME) in the doc string (emacs-lisp-checkdoc)
 quickru…   161     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickru…   466     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 quickru…   468     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 quickru…   473     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 quickru…   482     warning         Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
 quickru…   534     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickru…   586     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickru…   586     warning         Lisp symbol ‘major-mode’ should appear in quotes (emacs-lisp-checkdoc)
 quickru…   602     warning         Argument ‘lang’ should appear (as LANG) in the doc string (emacs-lisp-checkdoc)
 quickru…   612     warning         Argument ‘compile-conf’ should appear (as COMPILE-CONF) in the doc string (emacs-lisp-checkdoc)
 quickru…   621     warning         Argument ‘buf’ should appear (as BUF) in the doc string (emacs-lisp-checkdoc)
 quickru…   629     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickru…   658     warning         Argument ‘cmd-lst’ should appear (as CMD-LST) in the doc string (emacs-lisp-checkdoc)
 quickru…   675     warning         Argument ‘process’ should appear (as PROCESS) in the doc string (emacs-lisp-checkdoc)
 quickru…   685     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 quickru…   694     warning         Argument ‘cmd-lst’ should appear (as CMD-LST) in the doc string (emacs-lisp-checkdoc)
 quickru…   740     warning         Argument ‘cmd-str’ should appear (as CMD-STR) in the doc string (emacs-lisp-checkdoc)
 quickru…   747     warning         Argument ‘cmd-lst’ should appear (as CMD-LST) in the doc string (emacs-lisp-checkdoc)
 quickru…   771     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickru…   781     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickru…   786     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickru…   804     warning         Argument ‘process’ should appear (as PROCESS) in the doc string (emacs-lisp-checkdoc)
 quickru…   816     warning         Probably "Removes" should be imperative "Remove" (emacs-lisp-checkdoc)
 quickru…   825     warning         Probably "Kills" should be imperative "Kill" (emacs-lisp-checkdoc)
 quickru…   872     warning         Argument ‘outputter’ should appear (as OUTPUTTER) in the doc string (emacs-lisp-checkdoc)
 quickru…   877     warning         Argument ‘outputter’ should appear (as OUTPUTTER) in the doc string (emacs-lisp-checkdoc)
 quickru…   888     warning         Argument ‘file’ should appear (as FILE) in the doc string (emacs-lisp-checkdoc)
 quickru…   923     warning         Argument ‘bufname’ should appear (as BUFNAME) in the doc string (emacs-lisp-checkdoc)
 quickru…   930     warning         Argument ‘varname’ should appear (as VARNAME) in the doc string (emacs-lisp-checkdoc)
 quickru…   935     warning         Argument ‘op’ should appear (as OP) in the doc string (emacs-lisp-checkdoc)
 quickru…   965     warning         Argument ‘input-file’ should appear (as INPUT-FILE) in the doc string (emacs-lisp-checkdoc)
 quickru…   975     warning         Argument ‘input-file’ should appear (as INPUT-FILE) in the doc string (emacs-lisp-checkdoc)
 quickr…   986     warning         Argument ‘rest-commands’ should appear (as REST-COMMANDS) in the doc string (emacs-lisp-checkdoc)
 quickr…  1025     warning         Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
 quickr…  1029     warning         Argument ‘command’ should appear (as COMMAND) in the doc string (emacs-lisp-checkdoc)
 quickr…  1035     warning         Argument ‘src’ should appear (as SRC) in the doc string (emacs-lisp-checkdoc)
 quickr…  1042     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickr…  1064     warning         Argument ‘key’ should appear (as KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1073     warning         Argument ‘param’ should appear (as PARAM) in the doc string (emacs-lisp-checkdoc)
 quickr…  1092     warning         Argument ‘cmd-info’ should appear (as CMD-INFO) in the doc string (emacs-lisp-checkdoc)
 quickr…  1104     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1128     warning         Argument ‘tmpl’ should appear (as TMPL) in the doc string (emacs-lisp-checkdoc)
 quickr…  1146     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 quickr…  1147     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 quickr…  1154     warning         Argument ‘lang’ should appear (as LANG) in the doc string (emacs-lisp-checkdoc)
 quickr…  1156     warning         Error messages should *not* end with a period (emacs-lisp-checkdoc)
 quickr…  1160     warning         Argument ‘cmdkey’ should appear (as CMDKEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1179     warning         Messages should start with a capital letter (emacs-lisp-checkdoc)
 quickr…  1189     warning         Argument ‘candidates’ should appear (as CANDIDATES) in the doc string (emacs-lisp-checkdoc)
 quickr…  1195     warning         Argument ‘lang’ should appear (as LANG) in the doc string (emacs-lisp-checkdoc)
 quickr…  1211   1 error           "quicklang/lang-candidates" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1211   1 error           `quicklang/lang-candidates' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 quickr…  1224     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1259     warning         Second line should not have indentation (emacs-lisp-checkdoc)
 quickr…  1259     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 quickr…  1259     warning         Argument ‘plist’ should appear (as PLIST) in the doc string (emacs-lisp-checkdoc)
 quickr…  1260     warning         Keycode C-u embedded in doc string.  Use \\<keymap> & \\[function] instead (emacs-lisp-checkdoc)
 quickr…  1284     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1284     warning         Argument ‘arg’ should appear (as ARG) in the doc string (emacs-lisp-checkdoc)
 quickr…  1301     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1307     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1307     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1313     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1313     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1321     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1321     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1329     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1336     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1343     warning         Argument ‘removed-files’ should appear (as REMOVED-FILES) in the doc string (emacs-lisp-checkdoc)
 quickr…  1348     warning         Argument ‘src’ should appear (as SRC) in the doc string (emacs-lisp-checkdoc)
 quickr…  1355     warning         Argument ‘src’ should appear (as SRC) in the doc string (emacs-lisp-checkdoc)
 quickr…  1368     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1390     warning         Argument ‘buf’ should appear (as BUF) in the doc string (emacs-lisp-checkdoc)
 quickr…  1411     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1464   1 error           "helm-quickrun--actions" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1472   1 error           "helm-quickrun-source" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1479     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1479     warning         First line should be capitalized (emacs-lisp-checkdoc)
 quickr…  1483   1 error           "helm-quickrun-history-source" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1488     warning         First sentence should end with punctuation (emacs-lisp-checkdoc)
 quickr…  1488     warning         First line should be capitalized (emacs-lisp-checkdoc)
 quickr…  1491     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1496     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1502     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1512     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1518     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1524     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1530     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1536     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1542   1 error           "anything-quickrun" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1546     warning         Messages should start with a capital letter (emacs-lisp-checkdoc)
 quickr…  1546     warning         Error messages should *not* end with a period (emacs-lisp-checkdoc)
 quickr…  1550   1 error           "helm-quickrun" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1554     warning         Messages should start with a capital letter (emacs-lisp-checkdoc)
 quickr…  1554     warning         Error messages should *not* end with a period (emacs-lisp-checkdoc)
```

```emacs-lisp
 quickru…   109     warning         Argument ‘name’ should appear (as NAME) in the doc string (emacs-lisp-checkdoc)
 quickru…   602     warning         Argument ‘lang’ should appear (as LANG) in the doc string (emacs-lisp-checkdoc)
 quickru…   612     warning         Argument ‘compile-conf’ should appear (as COMPILE-CONF) in the doc string (emacs-lisp-checkdoc)
 quickru…   621     warning         Argument ‘buf’ should appear (as BUF) in the doc string (emacs-lisp-checkdoc)
 quickru…   629     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickru…   658     warning         Argument ‘cmd-lst’ should appear (as CMD-LST) in the doc string (emacs-lisp-checkdoc)
 quickru…   675     warning         Argument ‘process’ should appear (as PROCESS) in the doc string (emacs-lisp-checkdoc)
 quickru…   685     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 quickru…   694     warning         Argument ‘cmd-lst’ should appear (as CMD-LST) in the doc string (emacs-lisp-checkdoc)
 quickru…   740     warning         Argument ‘cmd-str’ should appear (as CMD-STR) in the doc string (emacs-lisp-checkdoc)
 quickru…   747     warning         Argument ‘cmd-lst’ should appear (as CMD-LST) in the doc string (emacs-lisp-checkdoc)
 quickru…   771     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickru…   781     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickru…   786     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickru…   804     warning         Argument ‘process’ should appear (as PROCESS) in the doc string (emacs-lisp-checkdoc)
 quickru…   872     warning         Argument ‘outputter’ should appear (as OUTPUTTER) in the doc string (emacs-lisp-checkdoc)
 quickru…   877     warning         Argument ‘outputter’ should appear (as OUTPUTTER) in the doc string (emacs-lisp-checkdoc)
 quickru…   888     warning         Argument ‘file’ should appear (as FILE) in the doc string (emacs-lisp-checkdoc)
 quickru…   923     warning         Argument ‘bufname’ should appear (as BUFNAME) in the doc string (emacs-lisp-checkdoc)
 quickru…   930     warning         Argument ‘varname’ should appear (as VARNAME) in the doc string (emacs-lisp-checkdoc)
 quickru…   935     warning         Argument ‘op’ should appear (as OP) in the doc string (emacs-lisp-checkdoc)
 quickru…   965     warning         Argument ‘input-file’ should appear (as INPUT-FILE) in the doc string (emacs-lisp-checkdoc)
 quickru…   975     warning         Argument ‘input-file’ should appear (as INPUT-FILE) in the doc string (emacs-lisp-checkdoc)
 quickr…   986     warning         Argument ‘rest-commands’ should appear (as REST-COMMANDS) in the doc string (emacs-lisp-checkdoc)
 quickr…  1028     warning         Argument ‘command’ should appear (as COMMAND) in the doc string (emacs-lisp-checkdoc)
 quickr…  1034     warning         Argument ‘src’ should appear (as SRC) in the doc string (emacs-lisp-checkdoc)
 quickr…  1041     warning         Argument ‘cmd’ should appear (as CMD) in the doc string (emacs-lisp-checkdoc)
 quickr…  1063     warning         Argument ‘key’ should appear (as KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1072     warning         Argument ‘param’ should appear (as PARAM) in the doc string (emacs-lisp-checkdoc)
 quickr…  1091     warning         Argument ‘cmd-info’ should appear (as CMD-INFO) in the doc string (emacs-lisp-checkdoc)
 quickr…  1103     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1127     warning         Argument ‘tmpl’ should appear (as TMPL) in the doc string (emacs-lisp-checkdoc)
 quickr…  1153     warning         Argument ‘lang’ should appear (as LANG) in the doc string (emacs-lisp-checkdoc)
 quickr…  1159     warning         Argument ‘cmdkey’ should appear (as CMDKEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1188     warning         Argument ‘candidates’ should appear (as CANDIDATES) in the doc string (emacs-lisp-checkdoc)
 quickr…  1194     warning         Argument ‘lang’ should appear (as LANG) in the doc string (emacs-lisp-checkdoc)
 quickr…  1210   1 error           "quicklang/lang-candidates" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1210   1 error           `quicklang/lang-candidates' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 quickr…  1257     warning         Second line should not have indentation (emacs-lisp-checkdoc)
 quickr…  1257     warning         First line is not a complete sentence (emacs-lisp-checkdoc)
 quickr…  1257     warning         Argument ‘plist’ should appear (as PLIST) in the doc string (emacs-lisp-checkdoc)
 quickr…  1258     warning         Keycode C-u embedded in doc string.  Use \\<keymap> & \\[function] instead (emacs-lisp-checkdoc)
 quickr…  1282     warning         Argument ‘arg’ should appear (as ARG) in the doc string (emacs-lisp-checkdoc)
 quickr…  1299     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1305     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1311     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1319     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1341     warning         Argument ‘removed-files’ should appear (as REMOVED-FILES) in the doc string (emacs-lisp-checkdoc)
 quickr…  1346     warning         Argument ‘src’ should appear (as SRC) in the doc string (emacs-lisp-checkdoc)
 quickr…  1353     warning         Argument ‘src’ should appear (as SRC) in the doc string (emacs-lisp-checkdoc)
 quickr…  1366     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1388     warning         Argument ‘buf’ should appear (as BUF) in the doc string (emacs-lisp-checkdoc)
 quickr…  1409     warning         Argument ‘start’ should appear (as START) in the doc string (emacs-lisp-checkdoc)
 quickr…  1462   1 error           "helm-quickrun--actions" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1471   1 error           "helm-quickrun-source" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1482   1 error           "helm-quickrun-history-source" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1490     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1495     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1501     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1511     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1517     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1523     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1529     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1535     warning         Argument ‘cmd-key’ should appear (as CMD-KEY) in the doc string (emacs-lisp-checkdoc)
 quickr…  1541   1 error           "anything-quickrun" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
 quickr…  1549   1 error           "helm-quickrun" doesn't start with package's prefix "quickrun". (emacs-lisp-package)
```