### PR TITLE
Adding support for command specific timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ list in order.
 If this parameter is omitted, `quickrun.el` use default execute
 command template "%c %o %s %a".
 
+#### `:timeout`(optional)
+
+Timeout in seconds for the process spawn by the command. This value
+takes precedence over the `quickrun-timeout-seconds` custom variable.
 
 #### `:compile-only`
 
@@ -286,7 +290,8 @@ This means that quickrun uses "c/clang" for C files.
 `quickrun.el` kills process if program run over 10 seconds as default.
 This avoids infinite loop program or endless program by some mistakes.
 You control timeout second to set `quickrun-timeout-seconds`.
-This feature is disabled if `quickrun-timeout-seconds` is `nil`.
+This feature is disabled if `quickrun-timeout-seconds` is `nil`. The
+timeout can also be set per command with the `:timeout` parameter.
 (You can also kill process by `C-c C-c` in quickrun buffer)
 
 

--- a/quickrun.el
+++ b/quickrun.el
@@ -1108,6 +1108,10 @@ Place holders are beginning with '%' and replaced by:
     (cl-loop for key in '(:compile-only)
              when (quickrun--extract-template key cmd-info)
              do (puthash key (quickrun--fill-template it tmpl-arg) info))
+    ;; numerical value (non template)
+    (cl-loop for key in '(:timeout)
+             when (assoc-default key cmd-info)
+             do (puthash key it info))
     ;; take one or more parameters
     (cl-loop for key in '(:exec :remove)
              when (quickrun--extract-template key cmd-info t)
@@ -1263,8 +1267,6 @@ But you can register your own command for some languages")
         (end (or (plist-get plist :end) (point-max)))
         (quickrun-option-cmd-alist (or quickrun-option-cmd-alist
                                        (plist-get plist :source)))
-        (quickrun-timeout-seconds (or quickrun-option-timeout-seconds
-                                      quickrun-timeout-seconds))
         (quickrun--compile-only-flag (or quickrun--compile-only-flag
                                          (and (consp current-prefix-arg)
                                               (= (car current-prefix-arg) 16)))))
@@ -1420,6 +1422,9 @@ But you can register your own command for some languages")
           (quickrun--copy-region-to-tempfile start end src)
         (setq src orig-src))
       (let ((cmd-info-hash (quickrun--fill-templates cmd-key src)))
+        (setq quickrun-timeout-seconds (or quickrun-option-timeout-seconds
+                                           (gethash :timeout cmd-info-hash)
+                                           quickrun-timeout-seconds))
         (quickrun--add-remove-files (gethash :remove cmd-info-hash))
         (unless quickrun-option-outputter
           (setq quickrun-option-outputter (gethash :outputter cmd-info-hash)))


### PR DESCRIPTION
With this, `:timeout` can be use as a parameter for a command. The value
of `:timeout` takes precedence over the custom variable quickrun-timeout-seconds
but is does not override the buffer local variable
quickrun-option-timeout-seconds.

This feature was suggested by me in a recent issue  #109.