### PR TITLE
Quote dir name if there are spaces in it

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -775,7 +775,7 @@ if you set your own language configuration.")
         (unless (file-directory-p formatted)
           (throw 'quickrun
                  (format "'%s' is not existed directory" it)))
-        (let* ((has-space (string-match " " formatted))
+        (let* ((has-space (string-match-p "[ \t]" formatted))
                (quoted-name (shell-quote-argument
                               (if has-space
                                 (concat "'" formatted "'")

--- a/quickrun.el
+++ b/quickrun.el
@@ -778,7 +778,7 @@ if you set your own language configuration.")
         (let* ((has-space (string-match-p "[ \t]" formatted))
                (quoted-name (shell-quote-argument
                               (if has-space
-                                (concat "'" formatted "'")
+                                (concat "\"" formatted "\"")
                                formatted)))))
         (setq quickrun-option-default-directory quoted-name)))))
 

--- a/quickrun.el
+++ b/quickrun.el
@@ -775,7 +775,12 @@ if you set your own language configuration.")
         (unless (file-directory-p formatted)
           (throw 'quickrun
                  (format "'%s' is not existed directory" it)))
-        (setq quickrun-option-default-directory formatted)))))
+        (let* ((has-space (string-match " " formatted))
+               (quoted-name (shell-quote-argument
+                              (if has-space
+                                (concat "'" formatted "'")
+                               formatted)))))
+        (setq quickrun-option-default-directory quoted-name)))))
 
 (defsubst quickrun--process-connection-type (cmd)
   "Not documented."


### PR DESCRIPTION
Fixes #118 
If a space exists in the path of the file, quickrun considers them as multiple arguments and throws an error. This PR adds a check to find spaces in the path and quote the path if a space is found, avoiding this error.
