### PR TITLE
Add vlang support

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -466,7 +466,6 @@ FMT and ARGS passed `message'."
     ("crystal" . ((:command . "crystal")
                   (:compile-only . "%c build %s")
                   (:description . "Run Crystal program")))
-
     ("v" . ((:command . "v")
 	    (:exec . "%c run %o %s %a")
 	    (:tempfile . nil)

--- a/quickrun.el
+++ b/quickrun.el
@@ -468,8 +468,9 @@ FMT and ARGS passed `message'."
                   (:description . "Run Crystal program")))
 
     ("v" . ((:command . "v")
-		(:exec . "%c run %s")
-		(:description . "Compile and run V/vlang program"))))
+	    (:exec . "%c run %o %s %a")
+	    (:tempfile . nil)
+	    (:description . "Compile and run V/vlang program"))))
 
   "List of each programming languages information.
 Parameter form is (\"language\" . parameter-alist).  parameter-alist has

--- a/quickrun.el
+++ b/quickrun.el
@@ -471,7 +471,7 @@ FMT and ARGS passed `message'."
 	    (:exec . "%c run %o %s %a")
 	    (:tempfile . nil)
 	    (:remove "%n")
-	    (:description . "Compile and run V/vlang program"))))
+	    (:description . "Compile and run V programs"))))
 
   "List of each programming languages information.
 Parameter form is (\"language\" . parameter-alist).  parameter-alist has

--- a/quickrun.el
+++ b/quickrun.el
@@ -465,7 +465,11 @@ FMT and ARGS passed `message'."
                  (:description . "Compile Kotlin file and execute")))
     ("crystal" . ((:command . "crystal")
                   (:compile-only . "%c build %s")
-                  (:description . "Run Crystal program"))))
+                  (:description . "Run Crystal program")))
+
+    ("v" . ((:command . "v")
+		(:exec . "%c run %s")
+		(:description . "Compile and run V/vlang program"))))
 
   "List of each programming languages information.
 Parameter form is (\"language\" . parameter-alist).  parameter-alist has
@@ -535,7 +539,8 @@ if you set your own language configuration.")
     ("\\.jl\\'" . "julia")
     ("\\.\\(gpi\\|plt\\)\\'" . "gnuplot")
     ("\\.kt\\'" . "kotlin")
-    ("\\.cr\\'" . "crystal"))
+    ("\\.cr\\'" . "crystal")
+    ("\\.v\\'" . "v"))
   "Alist of (file-regexp . key)")
 
 (defvar quickrun--major-mode-alist
@@ -588,7 +593,8 @@ if you set your own language configuration.")
     (julia-mode . "julia")
     (gnuplot-mode . "gnuplot")
     (kotlin-mode . "kotlin")
-    (crystal-mode . "crystal"))
+    (crystal-mode . "crystal")
+    (v-mode . "v"))
   "Alist of major-mode and langkey")
 
 (defun quickrun--decide-file-type (filename)
@@ -1155,7 +1161,7 @@ Place holders are beginning with '%' and replaced by:
     "javascript" "clojure" "erlang" "ocaml" "fsharp" "go" "io" "haskell" "java"
     "d" "markdown" "coffee" "scala" "groovy" "sass" "less" "shellscript" "awk"
     "lua" "rust" "dart" "elixir" "tcl" "jsx" "typescript" "fortran" "haml"
-    "swift" "ats" "r" "nim" "nimscript" "fish" "julia" "gnuplot" "kotlin" "crystal")
+    "swift" "ats" "r" "nim" "nimscript" "fish" "julia" "gnuplot" "kotlin" "crystal", "v")
   "Programming languages and Markup languages supported as default
 by quickrun.el. But you can register your own command for some languages")
 

--- a/quickrun.el
+++ b/quickrun.el
@@ -470,6 +470,7 @@ FMT and ARGS passed `message'."
     ("v" . ((:command . "v")
 	    (:exec . "%c run %o %s %a")
 	    (:tempfile . nil)
+	    (:remove "%n")
 	    (:description . "Compile and run V/vlang program"))))
 
   "List of each programming languages information.


### PR DESCRIPTION
This PR adds quickrun support to the [V programming language](https://vlang.io/). While the language is still under heavy development, the command-line tool is suitable to run programs.
