### PR TITLE
Fix outdated Dart argument

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -403,10 +403,10 @@ FMT and ARGS passed `message'."
                (:description . "Compile rust and execute")))
 
     ("dart/checked" . ((:command . "dart")
-                       (:cmdopt  . "--enable-type-checks")
-                       (:description . "Run dart with '--enable-type-checks' option")))
+                       (:cmdopt  . "--enable-asserts")
+                       (:description . "Run Dart with '--enable-asserts' option")))
     ("dart/production" . ((:command . "dart")
-                          (:description . "Run dart as without '--enable-type-checks' option")))
+                          (:description . "Run Dart WITHOUT '--enable-asserts' option")))
 
     ("elixir" . ((:command . "elixir")
                  (:description . "Run Elixir script")))


### PR DESCRIPTION
As Dart SDK version 2.9.2, there is no `--enable-type-checks` option. Instead, I added `--enable-asserts` option for the `dart/checked` command.


----

#