### PR TITLE
Ensure detection of '.C' extension as a C++ file

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -599,7 +599,8 @@ if you set your own language configuration.")
 (defun quickrun--decide-file-type (filename)
   "Decide file type by FILENAME."
   ;; First search by file extension, Second search by major-mode
-  (or (assoc-default filename quickrun-file-alist 'string-match)
+  (or (let (case-fold-search) (assoc-default filename quickrun-file-alist 'string-match))
+      (let ((case-fold-search t)) (assoc-default filename quickrun-file-alist 'string-match))
       (quickrun--find-from-major-mode-alist)))
 
 (defun quickrun--find-from-major-mode-alist ()


### PR DESCRIPTION
According to `quickrun-file-alist`, a source file with extension `.C` should be recognized
as a C++ file.
With the default value of `case-fold-search` (i.e. non-nil), this file will be wongly assumed as a Cee file.

```
(quickrun--decide-file-type "foo.C")
=>
"c"
```

Changing the order of "c" and "c++" at `quickrun-file-alist` is not a fix, because then `foo.c` will be
recognized as a C++ file.
Instead, try to match the file extension first with `case-fold-search` nil; if not match found, then try to
match with `case-fold-search` non-nil.

We explicitely set `case-fold-seach` non-nil the second time; this way, users still match, for instance,
`foo.F90` as a Fortran file, regardless their global customized value for `case-fold-search`.