### PR TITLE
Fix Travis deployment

### DIFF
--- a/Cask
+++ b/Cask
@@ -5,4 +5,4 @@
 
 (development
  (depends-on "helm")
- (depends-on "ert"))
+ (depends-on "ert-runner"))


### PR DESCRIPTION
Since a while ago, all Travis deployments are failing.
The reason seems to be an out-of-date dependency Cask file

* Cask: Update dependency: "ert" -> "ert-runner".

