### PR TITLE
Drop go script and fix dependency issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: generic
 sudo: false
 before_install:
-  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
-  - evm install $EVM_EMACS --use --skip
-  - cask
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - evm config path /tmp
+  - evm install emacs-24.3-travis --use --skip
+  - git clone https://github.com/cask/cask ~/.cask
+  - cask update
 env:
-  - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-24.4-travis PATH=$HOME/.cask/bin:$HOME/.evm/bin:$PATH
+  - EVM_EMACS=emacs-24.5-travis PATH=$HOME/.cask/bin:$HOME/.evm/bin:$PATH
+  - EVM_EMACS=emacs-25.1-travis PATH=$HOME/.cask/bin:$HOME/.evm/bin:$PATH
 script:
   - emacs --version
   - make test

--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ Sample is following:
                         (:exec . ("%c -bv --color %s"))))))
 ```
 
-[travis-badge]: https://travis-ci.org/syohex/emacs-quickrun.svg
-[travis-link]: https://travis-ci.org/syohex/emacs-quickrun
+[travis-badge]: https://travis-ci.org/emacsorphanage/quickrun.svg
+[travis-link]: https://travis-ci.org/github/emacsorphanage/quickrun/builds/
 [melpa-link]: https://melpa.org/#/quickrun
 [melpa-stable-link]: https://stable.melpa.org/#/quickrun
 [melpa-badge]: https://melpa.org/packages/quickrun-badge.svg


### PR DESCRIPTION
The `go` script installing `cask` has the following deprecation notice:
```
                DEPRECATION NOTICE


The cask `go` script will be removed on 2021/06/01.

This is due to security concerns about the way python is
invoked from curl, and to remove the python dependency from cask.

The way to install cask without depending on the `go` script
is very simple.  Just clone Cask and pass the PATH.

    git clone https://github.com/cask/cask ~/.cask
    PATH=$HOME/.cask/bin:$PATH

    # If you want to make it permanent
    echo 'PATH=$HOME/.cask/bin:$PATH' >> .bashrc
```

Follow this recommendation to install `cask` in a secure way.

* .travis.yml: Drop the deprecated `go` script; install `evm` and `cask`
explicitely.
Run `cask update` to fix issues with some dependencies.

* README.md: Update Travis URLs.

