### PR TITLE
tramp: Use tramp-file-name-localname

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -1063,7 +1063,7 @@ Place holders are beginning with '%' and replaced by:
   (let ((buffile (buffer-file-name)))
     (if (not (and buffile (file-remote-p buffile)))
         src
-      (aref (tramp-dissect-file-name (buffer-file-name)) 3))))
+      (tramp-file-name-localname (tramp-dissect-file-name (buffer-file-name))))))
 
 (defun quickrun--place-holder-info (cmd cmdopt source args)
   "Not documented."


### PR DESCRIPTION
Use `tramp-file-name-localname` instead of `aref` to extract the localname component of a tramp file name.

When attempting to use quickrun with a file loaded using tramp an error is seen indicating that the value returned by `tramp-dissect-file-name` is of the wrong type.  The current implementation of quickrun assumes this value is an array but current versions return a `tramp-file-name` struct.  This patch updates quickrun to use the `tramp-file-name-localname` accessor to retrieve the localname component of the file name.