### PR TITLE
Close popup when killing the quickrun buffer

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -1493,6 +1493,9 @@ With double prefix argument(C-u C-u), run in compile-only-mode."
 
 (defun quickrun--kill-quickrun-buffer ()
   "Kill quickrun buffer."
+  (let ((win (get-buffer-window quickrun--buffer-name)))
+      (when win
+        (delete-window win)))
   (when (get-buffer quickrun--buffer-name)
     (kill-buffer quickrun--buffer-name)))
 


### PR DESCRIPTION
Invoking quickrun  the kills the existing quickrun buffer, and its popup window gets replaced by some other buffer. A new popup windows starts opens up instead, leaving the old window lying there unnecessarily. This patch, closes the old popup window.
