### PR TITLE
Add idle autorun feature to quickrun-autorun-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ Replace region of code with its output.
 
 ### `quickrun-autorun-mode`
 
-Minor mode which executes `quickrun` after saving buffer.
+Minor mode which automatically executes `quickrun` after saving the buffer.
+If you set `quickrun-autorun-idle-delay` to a number, `quickrun` will also run automatically after the buffer has been idle for that many seconds, even without saving.
 
 #### `helm-quickrun`
 
@@ -171,6 +172,11 @@ If this value is `nil`, quickrun.el does not move focus to output buffer.
 ### `quickrun-truncate-lines`(Default: `t`)
 
 The `truncate-lines' value for `*quickrun*` buffer.
+
+### `quickrun-autorun-idle-delay` (Default: `nil`)
+
+Idle time in seconds before automatically running `quickrun` without saving.
+If `nil`, automatic execution without saving is disabled.
 
 ## User Defined Command
 


### PR DESCRIPTION
I've recently gotten used to the fact that [`php-play.dev`](https://php-play.dev/?c=DwfgDgFmBQ0KYGMIHsAEBLAtmANsgJnABTSpmoBEAOgHYUA0p5AhgE6vMCeA%2Bps2CXJDUAMxqoi6GgBdUAEhoBKVAF4AfKj7SkEgNoLUAUlQBmVSpWoADPXnjjAVnOWrAXWUBvJsOG7prAFc4W38g11UNCgAxdAAvWIAhAPiGbx9yP0Dg0WYcAGc4cPVKGJTGdN8RXIKQrKLIpLK0it0q-Oy2gvq7cvSAX16fDhoAc2IARlsTK0VB1FnoRQBuaCA&v=8.3&f=console) online sandbox in the browser runs code as soon as I type it.

This PR makes `quickrun-autorun-mode` "quicker" without saving.

This mode defaults to `quickrun` after saving as usual, but users can set the variable to a number to opt-in to `quickrun` without saving.

```el
(setopt quickrun-autorun-idle-delay 0.1)
```

https://github.com/user-attachments/assets/9b3ea8cc-678d-46d3-b20e-b42ac47f6421

https://github.com/user-attachments/assets/f5504898-a2c3-4782-9d85-ef9832ee5bfe