### PR TITLE
fix: auto focus in quickrun-shell

### DIFF
--- a/quickrun.el
+++ b/quickrun.el
@@ -1472,6 +1472,7 @@ With double prefix argument(C-u C-u), run in compile-only-mode."
   "Run commands in shell for interactive programs."
   (interactive)
   (let ((quickrun--run-in-shell t)
+        (quickrun-focus-p t)
         (quickrun-timeout-seconds nil))
     (quickrun)))
 


### PR DESCRIPTION
for command `quickrun-shell`, should auto focus on output buffer for interactive usage by default