### PR TITLE
feat: Add header and footer messages with exit code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Revision history for quickrun.el
 Version 2.3.1 N/A jcs090218
   - Support Deno (b8a9b716a8414c98d3a1ce9267c47c5dbbc7f67b)
   - Support Nix (#152)
+  - feat: Add header and footer messages with exit code (#157)
 
 Version 2.2.8 2017/01/14 syohex
   - Support julia (#77)


### PR DESCRIPTION
Example output:

```
-*- mode: quickrun-; default-directory: "/Users/xxx/quickrun/" -*-
Quickrun started at Wed Feb 12 23:36:02

<outout>

Quickrun exited abnormally with code 255 at Wed Feb 12 23:36:02
```